### PR TITLE
adds harp.js support

### DIFF
--- a/heuristics.go
+++ b/heuristics.go
@@ -45,6 +45,11 @@ var StaticSites = map[string]*StaticSiteType{
 		Canary:  "conf.py",
 		Command: "sphinx-build -b html $PANCAKE_SOURCE $PANCAKE_ARTIFACT_DIR",
 	},
+	"harp": {
+		Name:    "harp",
+		Canary:  "harp.json",
+		Command: "npm install && harp compile $PANCAKE_SOURCE $PANCAKE_ARTIFACT_DIR",
+	}
 }
 
 func gemfile(gem string) string {


### PR DESCRIPTION
Add support for https://harpjs.com/

Executes `npm install` before build, which assumes the user has harp in their npm dependencies, also assumes the user has a harp.json file (this is the canary), although this is optional with a harp.js site.
